### PR TITLE
react 16 compability

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,15 +83,15 @@
     "sass-loader": "^4.0.1",
     "style-loader": "^0.13.1",
     "timekeeper": "^0.1.1",
-    "webpack": "^1.13.2"    
+    "webpack": "^1.13.2"
   },
   "dependencies": {
     "classnames": "^2.2.5",
-    "react-addons-css-transition-group": "^15.3.1",
-    "react-addons-pure-render-mixin": "^15.3.1"    
+    "react-transition-group": "^1.2.1"
   },
   "peerDependencies": {
-    "react": ">= 15.0.0 < 16.0.0",
+    "prop-types": ">= 15.3.0 < 17.0.0",
+    "react": ">= 15.3.0 < 17.0.0",
     "react-redux": ">= 4.0.0 < 6.0.0",
     "redux": ">= 3.0.0 < 4.0.0"
   },

--- a/src/components/Notification/index.js
+++ b/src/components/Notification/index.js
@@ -1,44 +1,39 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
-import PureRenderMixin from 'react-addons-pure-render-mixin';
 import styleMap from './Notification.scss';
 
 
-export class Notification extends React.Component {
+export class Notification extends React.PureComponent {
 
   static propTypes = {
-    id: React.PropTypes.number.isRequired,
-    type: React.PropTypes.string.isRequired,
-    canDismiss: React.PropTypes.bool.isRequired,
-    duration: React.PropTypes.number.isRequired,
-    icon: React.PropTypes.node,
-    customStyles: React.PropTypes.object,
-    customComponent: React.PropTypes.element,
-    acceptBtn: React.PropTypes.shape({
-      handler: React.PropTypes.func.isRequired,
-      icon: React.PropTypes.node,
-      title: React.PropTypes.node,
+    id: PropTypes.number.isRequired,
+    type: PropTypes.string.isRequired,
+    canDismiss: PropTypes.bool.isRequired,
+    duration: PropTypes.number.isRequired,
+    icon: PropTypes.node,
+    customStyles: PropTypes.object,
+    customComponent: PropTypes.element,
+    acceptBtn: PropTypes.shape({
+      handler: PropTypes.func.isRequired,
+      icon: PropTypes.node,
+      title: PropTypes.node,
     }),
-    denyBtn: React.PropTypes.shape({
-      handler: React.PropTypes.func.isRequired,
-      icon: React.PropTypes.node,
-      title: React.PropTypes.node,
+    denyBtn: PropTypes.shape({
+      handler: PropTypes.func.isRequired,
+      icon: PropTypes.node,
+      title: PropTypes.node,
     }),
-    isFirst: React.PropTypes.bool.isRequired,
-    handleDismiss: React.PropTypes.func.isRequired,
-    handleDismissAll: React.PropTypes.func.isRequired,
-    styles: React.PropTypes.object.isRequired,
+    isFirst: PropTypes.bool.isRequired,
+    handleDismiss: PropTypes.func.isRequired,
+    handleDismissAll: PropTypes.func.isRequired,
+    styles: PropTypes.object.isRequired,
   }
 
   static defaultProps = {
     styles: styleMap,
     canDismiss: true,
     duration: 0,
-  }
-
-  constructor(props) {
-    super(props);
-    this.shouldComponentUpdate = PureRenderMixin.shouldComponentUpdate.bind(this);
   }
 
   componentDidMount() {

--- a/src/components/Notify/index.js
+++ b/src/components/Notify/index.js
@@ -1,27 +1,27 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
-import PureRenderMixin from 'react-addons-pure-render-mixin';
+import ReactCSSTransitionGroup from 'react-transition-group/CSSTransitionGroup';
 import { removeNotification, removeAllNotifications, NOTIFICATIONS_POS_TOP_RIGHT } from 'modules/Notifications';
 import { default as Notification } from 'components/Notification';
 import styleMap from './Notify.scss';
 
 
-export class Notify extends React.Component {
+export class Notify extends React.PureComponent {
 
   static propTypes = {
-    notifications: React.PropTypes.array.isRequired,
-    remove: React.PropTypes.func.isRequired,
-    removeAll: React.PropTypes.func.isRequired,
-    styles: React.PropTypes.object.isRequired,
-    customStyles: React.PropTypes.object,
-    notificationComponent: React.PropTypes.func,
-    transitionDurations: React.PropTypes.shape({
-      enter: React.PropTypes.number,
-      leave: React.PropTypes.number,
+    notifications: PropTypes.array.isRequired,
+    remove: PropTypes.func.isRequired,
+    removeAll: PropTypes.func.isRequired,
+    styles: PropTypes.object.isRequired,
+    customStyles: PropTypes.object,
+    notificationComponent: PropTypes.func,
+    transitionDurations: PropTypes.shape({
+      enter: PropTypes.number,
+      leave: PropTypes.number,
     }),
-    position: React.PropTypes.string,
-    forceClose: React.PropTypes.bool,
+    position: PropTypes.string,
+    forceClose: PropTypes.bool,
   }
 
   static defaultProps = {
@@ -37,7 +37,6 @@ export class Notify extends React.Component {
 
   constructor(props) {
     super(props);
-    this.shouldComponentUpdate = PureRenderMixin.shouldComponentUpdate.bind(this);
     this.handleDismiss = this._handleDismiss.bind(this);
     this.handleDismissAll = this._handleDismissAll.bind(this);
   }


### PR DESCRIPTION
+ force min version of react 15.3.0 https://www.npmjs.com/package/prop-types#react-15
+ add prop-types standalone package
+ replace react-addons-pure-render-mixin by built-in PureComponent
+ replace react-addons-css-transition-group by react-transition-group v1.x: https://www.npmjs.com/package/react-addons-css-transition-group