### PR TITLE
Replace U+274C cross with pure css-X

### DIFF
--- a/src/components/Notification/Notification.scss
+++ b/src/components/Notification/Notification.scss
@@ -148,12 +148,23 @@ $max-height: 150px;
   &:hover, &:focus {
     opacity: 1;
   }
+  &:before, &:after {
+    position: absolute;
+    left: 18px;
+    top: 10px;
+    content: ' ';
+    height: 14px;
+    width: 2px;
+    background-color: currentColor;
+  }
   &:active {
     opacity: .2;
   }
   &:before {
-    content: "\274C";
-    margin: 0;
+    transform: rotate(45deg);
+  }
+  &:after {
+    transform: rotate(-45deg);
   }
 }
 


### PR DESCRIPTION
Replaces the unicode cross with a simple CSS cross, which is simply two lines rotated 45 degrees in opposite directions.

Screenshot:
![2019-01-22-200442_359x63_scrot](https://user-images.githubusercontent.com/1507032/51558946-fa918a00-1e80-11e9-8016-b7ecc2e761fa.png)
